### PR TITLE
Add edinet project to featured projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,31 @@
                             </div>
                         </div>
                     </div>
+                    <div class="project-card">
+                        <div class="project-image">
+                            <div class="project-placeholder">
+                                <i class="fas fa-chart-line"></i>
+                            </div>
+                        </div>
+                        <div class="project-content">
+                            <h3 class="project-title">edinet</h3>
+                            <p class="project-description">
+                                A Python-based tool for retrieving and analyzing financial data from Japanese listed companies' securities reports through the EDINET API. Automates extraction of 25+ financial metrics and converts complex XBRL data to structured JSON.
+                            </p>
+                            <div class="project-tech">
+                                <span class="tech-tag">Python</span>
+                                <span class="tech-tag">EDINET API</span>
+                                <span class="tech-tag">XBRL</span>
+                                <span class="tech-tag">Yahoo Finance API</span>
+                            </div>
+                            <div class="project-links">
+                                <a href="https://github.com/mikanmarusan/edinet" class="project-link">
+                                    <i class="fab fa-github"></i>
+                                    Code
+                                </a>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- Added edinet project to the Featured Projects section on the portfolio page
- Follows the same format as the existing omniauth-yahoojp project

## Changes
- Added project card for edinet with description, tech stack, and GitHub link
- Used chart-line icon to represent financial data analysis tool

Closes #2