### PR TITLE
docs: apply boilerplate README, CLAUDE, and project rules

### DIFF
--- a/.claude/rules/01-no-build-tooling.md
+++ b/.claude/rules/01-no-build-tooling.md
@@ -1,0 +1,11 @@
+## Stack Purity
+
+Do NOT introduce a build pipeline, Jekyll config (`_config.yml`), package manager
+(npm / yarn / bundler / pip), CI workflows under `.github/workflows/`, analytics
+scripts, or any framework, without explicit user approval.
+
+**Why:** The site is intentionally plain HTML/CSS/JS for fast load, low
+maintenance, and no lock-in. Adding tooling reverses an explicit design choice.
+
+**How to apply:** If a task seems to require build tooling, stop and ask the user
+first. Prefer an in-place HTML/CSS/JS solution over introducing a dependency.

--- a/.claude/rules/02-public-repo-hygiene.md
+++ b/.claude/rules/02-public-repo-hygiene.md
@@ -1,0 +1,19 @@
+## Public Repository Hygiene
+
+This repository is **public**. Anything committed is world-readable and may be
+indexed by search engines.
+
+Do NOT commit:
+- Secrets: `.env*`, API keys, tokens, OAuth client secrets, private keys.
+- Personal contact info: email, phone, postal address. Public handles only
+  (`github.com/mikanmarusan`, `twitter.com/mikanmarusan`).
+- Local absolute paths: `/Users/...`, `/home/...`, machine names.
+
+**Why:** The site does not currently expose private contact info — adding it via
+committed Markdown would create a new, search-engine-indexable disclosure.
+
+**How to apply:**
+- Stage explicit files. Do NOT use `git add -A` or `git add .`.
+- Before committing, scan the staged diff for the patterns above.
+- This rule applies equally to commit messages, PR titles/bodies, and issue
+  text.

--- a/.claude/rules/03-cname-protection.md
+++ b/.claude/rules/03-cname-protection.md
@@ -1,0 +1,14 @@
+## CNAME Protection
+
+Do NOT modify or delete `CNAME` unless the user explicitly requests a custom
+domain change.
+
+**Why:** `CNAME` binds the custom domain `mikanmarusan.net` to the GitHub Pages
+site. Removing or changing it breaks the GitHub-Pages-side custom-domain
+routing — visitors are then served from the default `mikanmarusan.github.io`
+host (or hit a 404 if that is also affected) instead of `mikanmarusan.net`.
+DNS records for `mikanmarusan.net` live outside this repo and are not changed
+by edits to `CNAME`.
+
+**How to apply:** Treat `CNAME` as read-only. If a refactor or cleanup task
+appears to touch it, stop and confirm with the user first.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ build/
 # Backup files
 *.bak
 *.backup
+
+# Claude Code session artifacts (planning docs, agent reports)
+.plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,44 @@
-# CLAUDE.md
+# Project Instructions
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## WHY — Purpose & Context
 
-## Repository Type
-This is a GitHub Pages repository (mikanmarusan.github.io) for hosting a personal website or portfolio.
+This repository contains the source for my personal portfolio site, published at
+<https://mikanmarusan.net>. It exists to give a single, lightweight landing page
+that introduces me, lists featured open-source projects, and links to my public
+profiles. The site is intentionally hand-rolled — fast to load, simple to
+maintain, no framework lock-in.
 
-## Common Commands
-Since this is a new repository, typical GitHub Pages workflows will include:
+The repository is **public**. Anything committed here is world-readable.
 
-- `git add .` - Stage all changes
-- `git commit -m "message"` - Commit changes
-- `git push origin main` - Deploy changes to GitHub Pages
+## WHAT — Architecture & Key Decisions
 
-## Architecture Notes
-- GitHub Pages serves content from the `main` branch root directory
-- Static files (HTML, CSS, JS) should be placed in the root directory
-- Common structure includes:
-  - `index.html` - Main landing page
-  - `assets/` or `css/`, `js/`, `images/` directories for static resources
-  - `_config.yml` if using Jekyll (GitHub Pages' default static site generator)
+- **Stack:** plain static HTML/CSS/JS. No build step. No package manager. No
+  Jekyll (`_config.yml` is intentionally absent even though GitHub Pages
+  defaults to Jekyll).
+- **Files at repo root:**
+  - `index.html` — single landing page (Home / About / Projects / Contact)
+  - `styles.css` — site styles
+  - `script.js` — small DOM enhancements (mobile nav, smooth scroll, fade-ins)
+  - `terms.html`, `privacypolicy.html` — legal pages
+  - `CNAME` — binds the custom domain `mikanmarusan.net`
+- **Hosting:** GitHub Pages, user site, served from the `main` branch root.
+- **Deployment trigger:** every push to `main` redeploys the live site within
+  ~1 minute. Treat `main` as production.
+- **Dependencies (runtime, loaded by `index.html`):** Google Fonts (Inter),
+  cdnjs Font Awesome. No npm dependencies.
+- The featured-project list lives in `index.html` only. Do not duplicate it in
+  README.md or CLAUDE.md — they will drift.
 
-## Development Considerations
-- GitHub Pages has a build process that may take a few minutes to reflect changes
-- Local testing can be done by opening HTML files directly in a browser or using a local server
-- If using Jekyll, local development requires Ruby and the Jekyll gem
+## HOW — Development Workflow
+
+- **Local preview:** open `index.html` directly in a browser, or run
+  `python3 -m http.server 8000` from the repo root and visit
+  `http://localhost:8000/`.
+- **Branching:** create a feature branch before any change —
+  `<type>/<kebab-case-description>` (Conventional Commits). Never commit
+  directly to `main`.
+- **Commits:** Conventional Commits format (`<type>(<scope>): <summary>`).
+- **Deploy:** merge to `main` via PR; GitHub Pages republishes automatically.
+  No separate build step.
+- **Project-specific guardrails** live under `.claude/rules/`. Read every file
+  in that directory before making changes.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# mikanmarusan.github.io
+
+Source for my personal portfolio site, published at <https://mikanmarusan.net>.
+
+## Site
+
+- Live site: <https://mikanmarusan.net>
+- Terms of Service: <https://mikanmarusan.net/terms.html>
+- Privacy Policy: <https://mikanmarusan.net/privacypolicy.html>
+
+## Contact
+
+- GitHub: <https://github.com/mikanmarusan>
+- X: <https://twitter.com/mikanmarusan>


### PR DESCRIPTION
## Summary

Apply the user's `claude-code-project-structure` boilerplate to this github.io repository, scoped to documentation only. Adds a minimal `README.md`, rewrites the outdated `CLAUDE.md` to the boilerplate's WHY / WHAT / HOW template, and populates `.claude/rules/` with three project-specific guardrails (no build tooling, public-repo hygiene, CNAME protection). Site files (`index.html`, `CNAME`, `styles.css`, `script.js`, `terms.html`, `privacypolicy.html`) are untouched, so there is no impact on the deployed site at `mikanmarusan.net`.

## Changes

- Add `README.md` at repo root — minimal English file with canonical site and contact links only
- Rewrite `CLAUDE.md` from the outdated Jekyll-mentioning stub to a WHY / WHAT / HOW description of the actual stack (plain HTML/CSS/JS, no build, custom domain via `CNAME`, deploy = push to `main`)
- Add `.claude/rules/01-no-build-tooling.md` — do not introduce Jekyll, package managers, CI workflows, or analytics without explicit approval
- Add `.claude/rules/02-public-repo-hygiene.md` — do not commit secrets, personal contact info, or local absolute paths to this public repo
- Add `.claude/rules/03-cname-protection.md` — do not modify `CNAME` without an explicit custom-domain change request
- Update `.gitignore` to exclude `.plans/` so Claude Code session artifacts stay out of the public repo