### PR TITLE
feat(contact): add Hatena Blog link

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,10 @@
                             <i class="fab fa-x-twitter"></i>
                             <span>X</span>
                         </a>
+                        <a href="https://mikanmarusan.hatenablog.com/" class="contact-link">
+                            <i class="fas fa-blog"></i>
+                            <span>Blog</span>
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Adds a link to the owner's Hatena Blog in the `#contact` section so visitors can find the author's writing alongside their code and social profiles.

## Changes
- Add a new `.contact-link` anchor pointing to `https://mikanmarusan.hatenablog.com/` in `index.html`, alongside the existing GitHub and X links.
- Reuse the existing `.contact-link` class and Font Awesome `fas fa-blog` icon (already loaded via CDN — no new dependencies).
- Match the existing convention: no `target="_blank"`, no `rel`.

## Verification
- No `package.json` or `Makefile` lint/typecheck scripts in this repo, so automated linting/typecheck does not apply.
- Code reviewed by the `x-code-reviewer` agent: zero Critical, zero Warning findings.

Closes #4