### PR TITLE
chore(deps): align Font Awesome CDN to 6.7.2

### DIFF
--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -6,7 +6,7 @@
     <title>プライバシーポリシー - mikanmarusan</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
 </head>
 <body>
     <nav class="navbar">

--- a/terms.html
+++ b/terms.html
@@ -6,7 +6,7 @@
     <title>利用規約 - mikanmarusan</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
 </head>
 <body>
     <nav class="navbar">


### PR DESCRIPTION
## Summary

Unify the Font Awesome CDN version across every top-level HTML page so icons render consistently and only one CSS bundle is fetched per visitor session. `index.html` was already on `6.7.2`; the two legal pages lagged on `6.0.0`.

## Changes

- Bump `terms.html:9` Font Awesome from `6.0.0` to `6.7.2`.
- Bump `privacypolicy.html:9` Font Awesome from `6.0.0` to `6.7.2`.
- `index.html` left unchanged (already `6.7.2`). All three URLs are now byte-for-byte identical.

## Verification

- Confirmed all three HTML files now reference the identical `6.7.2` CDN URL.
- Neither `terms.html` nor `privacypolicy.html` contains any `<i class="fa-*">` icon elements, so the bump carries no visual icon risk; the stylesheet is loaded only for cache consistency.
- No `package.json` or `Makefile` lint/typecheck targets exist in this plain static site, so those steps were skipped (no tooling to run).

Closes #5